### PR TITLE
Provide Array for Route Pattern

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -12,11 +12,23 @@ exports.register = function (server, options, next) {
     ignore: options.ignore
   }
 
-  var files = glob.sync(options.routes, globOptions);
+  var patterns = [];
 
-  files.forEach(function (file) {
-    server.route(require(globOptions.cwd + '/' + file));
-  });
+  if (typeof options.routes === typeof patterns) {
+    patterns = options.routes;
+  } else {
+    patterns = [ options.routes ];
+  }
+
+  console.log(patterns)
+
+  patterns.forEach(function (pattern) {
+    var files = glob.sync(pattern, globOptions);
+
+    files.forEach(function (file) {
+      server.route(require(globOptions.cwd + '/' + file));
+    });
+  })
 
   next();
 };

--- a/test/index.js
+++ b/test/index.js
@@ -23,6 +23,17 @@ describe('hapi-router', function () {
     });
   }
 
+  it('can take an array of route patterns', function () {
+    register({
+      routes: [
+        'test/routes/*.js',
+        'test/routes/api/*.js'
+      ]
+    });
+
+    expect(server.connections[0].table()).to.have.length(2);
+  });
+
   it('can load routes recursively', function () {
     register({
       routes: 'test/routes/**/*.js'


### PR DESCRIPTION
This PR allows for the following signature to be valid:

```
    register({
      routes: ['routes/api/*.js', 'routes/secret/*.js'],
      cwd: process.cwd() + '/test'
    });
```