### PR TITLE
Fix issue requiring route with export default syntax

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -15,7 +15,8 @@ exports.register = function (server, options, next) {
     var files = glob.sync(pattern, globOptions)
 
     files.forEach(function (file) {
-      server.route(require(globOptions.cwd + '/' + file))
+      var route = require(globOptions.cwd + '/' + file)
+      server.route(route.default || route)
     })
   })
 


### PR DESCRIPTION
Fixed a issue exporting a route with new es6 syntax `export default []` instead of `module.exports = []`

`routes.default` should manually be called then