### PR TITLE
Hapi v18

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,20 @@ Route loader for [hapi](https://github.com/spumko/hapi).
 
 ## Hapi v17
 
-`hapi-router` requires Hapi v17. If you're using a previous version of Hapi, use `hapi-router@3.5.0`
+`hapi-router` requires Hapi v18.
+
+* Hapi 18, hapi-router@5
+* Hapi 17, hapi-router@4
+* Hapi <= 16, hapi-router@3
 
 ## Install
 
 ```bash
+// If you're using Hapi v18
+$ npm i -S hapi-router@5
+
 // If you're using Hapi v17
-$ npm i -S hapi-router
+$ npm i -S hapi-router@4
 
 // If you're using < Hapi v17
 $ npm i -S hapi-router@3.5.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,14 +4,315 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "accept": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/accept/-/accept-3.0.2.tgz",
-      "integrity": "sha512-bghLXFkCOsC1Y2TZ51etWfKDs6q249SAoHTZVfzWWdlZxoij+mgkj9AmUJWQpDY48TfnrTDIe43Xem4zdMe7mQ==",
+    "@hapi/accept": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@hapi/accept/-/accept-3.2.2.tgz",
+      "integrity": "sha512-UtXlTT59srtMr7ZRBzK2CvyWqFwlf78hPt9jEXqkwfbwiwRH1PRv/qkS8lgr5ZyoG6kfpU3xTgt2X91Yfe/6Yg==",
       "dev": true,
       "requires": {
-        "boom": "7.1.1",
-        "hoek": "5.0.2"
+        "@hapi/boom": "7.4.2",
+        "@hapi/hoek": "6.2.1"
+      }
+    },
+    "@hapi/address": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.0.0.tgz",
+      "integrity": "sha512-mV6T0IYqb0xL1UALPFplXYQmR0twnXG0M6jUswpquqT2sD12BOiCiLy3EvMp/Fy7s3DZElC4/aPjEjo2jeZpvw==",
+      "dev": true
+    },
+    "@hapi/ammo": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/ammo/-/ammo-3.1.0.tgz",
+      "integrity": "sha512-iFQBEfm3WwWy8JdPQ8l6qXVLPtzmjITVfaxwl6dfoP8kKv6i2Uk43Ax+ShkNfOVyfEnNggqL2IyZTY3DaaRGNg==",
+      "dev": true,
+      "requires": {
+        "@hapi/hoek": "6.2.1"
+      }
+    },
+    "@hapi/b64": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@hapi/b64/-/b64-4.2.0.tgz",
+      "integrity": "sha512-hmfPC1aF7cP21489A/IWPC3s1GE+1eAteVwFcOWLwj0Pky8eHgvrXPSSko2IeCpxqOdZhYw71IFN8xKPdv3CtQ==",
+      "dev": true,
+      "requires": {
+        "@hapi/hoek": "6.2.1"
+      }
+    },
+    "@hapi/boom": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-7.4.2.tgz",
+      "integrity": "sha512-T2CYcTI0AqSvC6YC7keu/fh9LVSMzfoMLharBnPbOwmc+Cexj9joIc5yNDKunaxYq9LPuOwMS0f2B3S1tFQUNw==",
+      "dev": true,
+      "requires": {
+        "@hapi/hoek": "6.2.1"
+      }
+    },
+    "@hapi/bounce": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@hapi/bounce/-/bounce-1.3.0.tgz",
+      "integrity": "sha512-gF5W/9AL10h/06HEf1bi0FP6KxZZ8LC/yHtDuoACw+1HrULvigHfnBIaSPFJXeHI3V3g0EkJpt1UOW0NKB+m+w==",
+      "dev": true,
+      "requires": {
+        "@hapi/boom": "7.4.2",
+        "@hapi/hoek": "6.2.1"
+      }
+    },
+    "@hapi/bourne": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-1.3.0.tgz",
+      "integrity": "sha512-0Rpd7F7Q3aPaBE8mI0w6FNANvpEJoeOL+uwIExfrrbKWBtGSx9vmumLDnQBQmPOGmbKVrBNjjmeu1QshQ82QTw==",
+      "dev": true
+    },
+    "@hapi/call": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/call/-/call-5.1.0.tgz",
+      "integrity": "sha512-CiVEXjD/jiIHBqufBW3pdedshEMjRmHtff7m1puot8j4MUmuKRbLlh0DB8fv6QqH/7/55pH1qgFj300r0WpyMw==",
+      "dev": true,
+      "requires": {
+        "@hapi/boom": "7.4.2",
+        "@hapi/hoek": "6.2.1"
+      }
+    },
+    "@hapi/catbox": {
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/@hapi/catbox/-/catbox-10.2.1.tgz",
+      "integrity": "sha512-u13BXlnmmrNUZssjTriRVTLuk6I/yUy5C1/Pia1+E2cpfd7o2/jmEvYdFgeS0Ft9QTz7WWhpXKlrguARUuohhQ==",
+      "dev": true,
+      "requires": {
+        "@hapi/boom": "7.4.2",
+        "@hapi/hoek": "6.2.1",
+        "@hapi/joi": "15.0.0",
+        "@hapi/podium": "3.4.0"
+      }
+    },
+    "@hapi/catbox-memory": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/catbox-memory/-/catbox-memory-4.1.0.tgz",
+      "integrity": "sha512-libCGyufOZaJu6uE9nVXw/u8tqOt4ifNIrOSAsDjzS+af3vPJyid8faOICqKCAh3E338UAsUe5AeYdezdsmtpg==",
+      "dev": true,
+      "requires": {
+        "@hapi/boom": "7.4.2",
+        "@hapi/hoek": "6.2.1"
+      }
+    },
+    "@hapi/code": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@hapi/code/-/code-5.3.1.tgz",
+      "integrity": "sha512-gPOtttouEx0BGusbm3cNKJ7x0y6mdXt6D08xXxaDvv9TaY1/oqn+dd3L4vkwIfrQGiHRFU6x00d26MrtknWjAQ==",
+      "dev": true,
+      "requires": {
+        "@hapi/hoek": "6.2.1"
+      }
+    },
+    "@hapi/content": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/content/-/content-4.1.0.tgz",
+      "integrity": "sha512-hv2Czsl49hnWDEfRZOFow/BmYbKyfEknmk3k83gOp6moFn5ceHB4xVcna8OwsGfy8dxO81lhpPy+JgQEaU4SWw==",
+      "dev": true,
+      "requires": {
+        "@hapi/boom": "7.4.2"
+      }
+    },
+    "@hapi/cryptiles": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@hapi/cryptiles/-/cryptiles-4.2.0.tgz",
+      "integrity": "sha512-P+ioMP1JGhwDOKPRuQls6sT/ln6Fk+Ks6d90mlBi6HcOu5itvdUiFv5Ynq2DvLadPDWaA43lwNxkfZrjE9s2MA==",
+      "dev": true,
+      "requires": {
+        "@hapi/boom": "7.4.2"
+      }
+    },
+    "@hapi/hapi": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-18.3.1.tgz",
+      "integrity": "sha512-gBiU9isWWezrg0ucX95Ph6AY6fUKZub3FxKapaleoFBJDOUcxTYiQR6Lha2zvHalIFoTl3K04O3Yr/5pD17QkQ==",
+      "dev": true,
+      "requires": {
+        "@hapi/accept": "3.2.2",
+        "@hapi/ammo": "3.1.0",
+        "@hapi/boom": "7.4.2",
+        "@hapi/bounce": "1.3.0",
+        "@hapi/call": "5.1.0",
+        "@hapi/catbox": "10.2.1",
+        "@hapi/catbox-memory": "4.1.0",
+        "@hapi/heavy": "6.2.0",
+        "@hapi/hoek": "6.2.1",
+        "@hapi/joi": "15.0.0",
+        "@hapi/mimos": "4.1.0",
+        "@hapi/podium": "3.4.0",
+        "@hapi/shot": "4.1.0",
+        "@hapi/somever": "2.1.0",
+        "@hapi/statehood": "6.1.0",
+        "@hapi/subtext": "6.1.0",
+        "@hapi/teamwork": "3.3.0",
+        "@hapi/topo": "3.1.0"
+      }
+    },
+    "@hapi/heavy": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@hapi/heavy/-/heavy-6.2.0.tgz",
+      "integrity": "sha512-tzGU9cElY0IxRBudGB7tLFkdpBD8XQPfd6G7DSOnvHRK+q96UHGHn4t59Yd7kDpVucNkErWWYarsGx2KmKPkXA==",
+      "dev": true,
+      "requires": {
+        "@hapi/boom": "7.4.2",
+        "@hapi/hoek": "6.2.1",
+        "@hapi/joi": "15.0.0"
+      }
+    },
+    "@hapi/hoek": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-6.2.1.tgz",
+      "integrity": "sha512-+ryw4GU9pjr1uT6lBuErHJg3NYqzwJTvZ75nKuJijEzpd00Uqi6oiawTGDDf5Hl0zWmI7qHfOtaqB0kpQZJQzA==",
+      "dev": true
+    },
+    "@hapi/iron": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/iron/-/iron-5.1.0.tgz",
+      "integrity": "sha512-+MK3tBPkEKd50SrDTRXa2DVvE0UTPFKxGbodlbQpNP9SVlxi+ZwA640VJtMNj84FZh81UUxda8AOLPRKFffnEA==",
+      "dev": true,
+      "requires": {
+        "@hapi/b64": "4.2.0",
+        "@hapi/boom": "7.4.2",
+        "@hapi/cryptiles": "4.2.0",
+        "@hapi/hoek": "6.2.1"
+      }
+    },
+    "@hapi/joi": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-15.0.0.tgz",
+      "integrity": "sha512-pLCfcSeT26g59jEKZntmzlqe19dRMDNxCFKGD4CriF8+9FAD3Mq1aWNuKIFpKpX+u3x8lxLKXolDwk0gYl3b2w==",
+      "dev": true,
+      "requires": {
+        "@hapi/address": "2.0.0",
+        "@hapi/hoek": "6.2.1",
+        "@hapi/topo": "3.1.0"
+      }
+    },
+    "@hapi/mimos": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/mimos/-/mimos-4.1.0.tgz",
+      "integrity": "sha512-CkxOB15TFZDMl5tQ5qezKZvvBnkRYVc8YksNfA5TnqQMMsU7vGPyvuuNFqj+15bfEwHyM6qasxyQNdkX9B/cQw==",
+      "dev": true,
+      "requires": {
+        "@hapi/hoek": "6.2.1",
+        "mime-db": "1.40.0"
+      }
+    },
+    "@hapi/nigel": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/nigel/-/nigel-3.1.0.tgz",
+      "integrity": "sha512-IJyau32pz5Bf7pzUU/8AIn/SvPvhLMQcOel6kM7ECpKyPc895AwttSusRKfgTwfxZOEG6W8DnNv25gLtqrVFSg==",
+      "dev": true,
+      "requires": {
+        "@hapi/hoek": "6.2.1",
+        "@hapi/vise": "3.1.0"
+      }
+    },
+    "@hapi/pez": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/pez/-/pez-4.1.0.tgz",
+      "integrity": "sha512-c+AxL8/cCj+7FB+tzJ5FhWKYP8zF7/7mA3Ft3a5y7h6YT26qzhj5d2JY27jur30KaZbrZAd4ofXXkqvE/IpJlA==",
+      "dev": true,
+      "requires": {
+        "@hapi/b64": "4.2.0",
+        "@hapi/boom": "7.4.2",
+        "@hapi/content": "4.1.0",
+        "@hapi/hoek": "6.2.1",
+        "@hapi/nigel": "3.1.0"
+      }
+    },
+    "@hapi/podium": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@hapi/podium/-/podium-3.4.0.tgz",
+      "integrity": "sha512-IwyewAPGlCoq+g5536PKSDqSTfgpwbj+q4cBJpEUNqzwc5C5SM2stuFsULU7x1jKeWevfgWDoYWC75ML4IOYug==",
+      "dev": true,
+      "requires": {
+        "@hapi/hoek": "6.2.1",
+        "@hapi/joi": "15.0.0"
+      }
+    },
+    "@hapi/shot": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/shot/-/shot-4.1.0.tgz",
+      "integrity": "sha512-rpUU5cF08fqAZLLnue6Sy0osj1QMPbrYskehxtLFPdk7CwlPcu9N/wRtgu7vDHTQCKTkag6M8sjc8V8p8lSxpg==",
+      "dev": true,
+      "requires": {
+        "@hapi/hoek": "6.2.1",
+        "@hapi/joi": "15.0.0"
+      }
+    },
+    "@hapi/somever": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/somever/-/somever-2.1.0.tgz",
+      "integrity": "sha512-kMPewbpgLd0MSlNg0bjvq57Levozbg7c3O0idpWRxRgXfXBALNATLf8GRVbnMehYXAh7YRD2mR/91kginDtJ2Q==",
+      "dev": true,
+      "requires": {
+        "@hapi/bounce": "1.3.0",
+        "@hapi/hoek": "6.2.1"
+      }
+    },
+    "@hapi/statehood": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/statehood/-/statehood-6.1.0.tgz",
+      "integrity": "sha512-qc8Qq3kg0b3XK7siXf6DK0wp+rcOrXv336kIP6YrtD9TbQ45TsBobwKkUXB+4R3GCCQ8a6tOj8FR/9bdtjKJCA==",
+      "dev": true,
+      "requires": {
+        "@hapi/boom": "7.4.2",
+        "@hapi/bounce": "1.3.0",
+        "@hapi/bourne": "1.3.0",
+        "@hapi/cryptiles": "4.2.0",
+        "@hapi/hoek": "6.2.1",
+        "@hapi/iron": "5.1.0",
+        "@hapi/joi": "15.0.0"
+      }
+    },
+    "@hapi/subtext": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/subtext/-/subtext-6.1.0.tgz",
+      "integrity": "sha512-dNL4IspNciKUK9RJuArwyS1MO07ZU64z4JrCzY1+vRKczYqin8M5i34cpOrQNP3pD/A/6IbRcFg0Jl0G6pwjnA==",
+      "dev": true,
+      "requires": {
+        "@hapi/boom": "7.4.2",
+        "@hapi/bourne": "1.3.0",
+        "@hapi/content": "4.1.0",
+        "@hapi/hoek": "6.2.1",
+        "@hapi/pez": "4.1.0",
+        "@hapi/wreck": "15.0.1"
+      }
+    },
+    "@hapi/teamwork": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@hapi/teamwork/-/teamwork-3.3.0.tgz",
+      "integrity": "sha512-8lMcMkKvt182O/IPsqSDL9KVCsnZRXYKfvBywVOEDa2kCCbHe+lC/7NEu9tc5FYXTQl9uKSurAjyCY3sPP2PFQ==",
+      "dev": true
+    },
+    "@hapi/topo": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.0.tgz",
+      "integrity": "sha512-gZDI/eXOIk8kP2PkUKjWu9RW8GGVd2Hkgjxyr/S7Z+JF+0mr7bAlbw+DkTRxnD580o8Kqxlnba9wvqp5aOHBww==",
+      "dev": true,
+      "requires": {
+        "@hapi/hoek": "6.2.1"
+      }
+    },
+    "@hapi/vise": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/vise/-/vise-3.1.0.tgz",
+      "integrity": "sha512-DUDzV0D4iVO5atghsjGZtzaF0HVtRLcxcnH6rAONyH0stnoLiFloGEuP5nkbIPU0B9cgWTzTUsQPuNHBzxy9Yw==",
+      "dev": true,
+      "requires": {
+        "@hapi/hoek": "6.2.1"
+      }
+    },
+    "@hapi/wreck": {
+      "version": "15.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-15.0.1.tgz",
+      "integrity": "sha512-ByXQna/W1FZk7dg8NEhL79u4QkhzszRz76VpgyGstSH8bLM01a0C8RsxmUBgi6Tjkag5jA9kaEIhF9dLpMrtBw==",
+      "dev": true,
+      "requires": {
+        "@hapi/boom": "7.4.2",
+        "@hapi/bourne": "1.3.0",
+        "@hapi/hoek": "6.2.1"
       }
     },
     "acorn": {
@@ -71,27 +372,6 @@
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
       "dev": true
-    },
-    "ammo": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ammo/-/ammo-3.0.0.tgz",
-      "integrity": "sha512-6yoz9MXYV9sgCHrwprHWPxBaJ9/roQRfXzS//4JCNgKfPYcghFNwJQKBt6vWOoSGGRHsP6qsLJ+xtKStKJWdLQ==",
-      "dev": true,
-      "requires": {
-        "boom": "6.0.0",
-        "hoek": "5.0.2"
-      },
-      "dependencies": {
-        "boom": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-6.0.0.tgz",
-          "integrity": "sha512-LYLa8BmiiOWjvxTMVh73lcZzd2E5yczrKvxAny1UuzO2tkarLrw4tdp3rdfmus3+YfKcZP0vRSM3Obh+fGK6eA==",
-          "dev": true,
-          "requires": {
-            "hoek": "5.0.2"
-          }
-        }
-      }
     },
     "ansi-escapes": {
       "version": "1.4.0",
@@ -157,12 +437,6 @@
       "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
       "dev": true
     },
-    "b64": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/b64/-/b64-4.0.0.tgz",
-      "integrity": "sha512-EhmUQodKB0sdzPPrbIWbGqA5cQeTWxYrAgNeeT1rLZWtD3tbNTnphz8J4vkXI3cPgBNlXBjzEbzDzq0Nwi4f9A==",
-      "dev": true
-    },
     "babel-code-frame": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
@@ -187,12 +461,6 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
-    "big-time": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/big-time/-/big-time-2.0.0.tgz",
-      "integrity": "sha512-OXsmBxlRLwUc65MLta2EOyMTLcjZQkxHkJ81lVPeyVqZag8zhUfKRYIbF3E/IW/LWR8kf8a1GlRYkBXKVGqJOw==",
-      "dev": true
-    },
     "boom": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/boom/-/boom-7.1.1.tgz",
@@ -213,16 +481,6 @@
         "joi": "13.0.2"
       }
     },
-    "bounce": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/bounce/-/bounce-1.2.0.tgz",
-      "integrity": "sha512-8syCGe8B2/WC53118/F/tFy5aW00j+eaGPXmAUP7iBhxc+EBZZxS1vKelWyBCH6IqojgS2t1gF0glH30qAJKEw==",
-      "dev": true,
-      "requires": {
-        "boom": "7.1.1",
-        "hoek": "5.0.2"
-      }
-    },
     "brace-expansion": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
@@ -237,16 +495,6 @@
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
       "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
       "dev": true
-    },
-    "call": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/call/-/call-5.0.1.tgz",
-      "integrity": "sha512-ollfFPSshiuYLp7AsrmpkQJ/PxCi6AzV81rCjBwWhyF2QGyUY/vPDMzoh4aUcWyucheRglG2LaS5qkIEfLRh6A==",
-      "dev": true,
-      "requires": {
-        "boom": "7.1.1",
-        "hoek": "5.0.2"
-      }
     },
     "caller-path": {
       "version": "0.1.0",
@@ -276,29 +524,6 @@
       "integrity": "sha1-Jk7xEp5YiLxIysQP6RTp9puNGJ0=",
       "requires": {
         "isarray": "0.0.1"
-      }
-    },
-    "catbox": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/catbox/-/catbox-10.0.2.tgz",
-      "integrity": "sha512-cTQTQeKMhWHU0lX8CADE3g1koGJu+AlcWFzAjMX/8P+XbkScGYw3tJsQpe2Oh8q68vOQbOLacz9k+6V/F3Z9DA==",
-      "dev": true,
-      "requires": {
-        "boom": "7.1.1",
-        "bounce": "1.2.0",
-        "hoek": "5.0.2",
-        "joi": "13.0.2"
-      }
-    },
-    "catbox-memory": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/catbox-memory/-/catbox-memory-3.1.1.tgz",
-      "integrity": "sha512-fl6TI/uneeUb9NGClKWZWkpCZQrkPmuVz/Jaqqb15vqW6KGfJ/vMP/ZMp8VgAkyTrrRvFHbFcS67sbU7EkvbhQ==",
-      "dev": true,
-      "requires": {
-        "big-time": "2.0.0",
-        "boom": "7.1.1",
-        "hoek": "5.0.2"
       }
     },
     "center-align": {
@@ -387,15 +612,6 @@
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
       "dev": true
     },
-    "code": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/code/-/code-5.1.2.tgz",
-      "integrity": "sha512-Typ0BuWOKPGNOY9M7hBDY60J9uSPok4Y7hhtTG/3Cpqg0/AhauZSWax0Mb0lZuzm89w1YgVvl8BTrBW/4Sw6sw==",
-      "dev": true,
-      "requires": {
-        "hoek": "5.0.2"
-      }
-    },
     "code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
@@ -439,15 +655,6 @@
       "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
       "dev": true
     },
-    "content": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/content/-/content-4.0.3.tgz",
-      "integrity": "sha512-BrMfT1xXZHaXyPT/sneXc3IQzh8uL15JWV1R5tU0xo4sBGjF7BN+IRi9WoQLSbfNEs7bJ3E69rjxBKg/RL7lOQ==",
-      "dev": true,
-      "requires": {
-        "boom": "7.1.1"
-      }
-    },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -475,15 +682,6 @@
             "yallist": "2.1.2"
           }
         }
-      }
-    },
-    "cryptiles": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-4.1.1.tgz",
-      "integrity": "sha512-YuQUPbcOmaZsdvxJZ25DCA1W+lLIRoPJKBDKin+St1RCYEERSfoe1d25B1MvWNHN3e8SpFSVsqYvEUjp8J9H2w==",
-      "dev": true,
-      "requires": {
-        "boom": "7.1.1"
       }
     },
     "d": {
@@ -1343,31 +1541,6 @@
         }
       }
     },
-    "hapi": {
-      "version": "17.2.0",
-      "resolved": "https://registry.npmjs.org/hapi/-/hapi-17.2.0.tgz",
-      "integrity": "sha512-zw2tqNimjT+qglgUNGNpeweHJ5To1xUcJcfGKsG5dWiTzwkEZtmtHJ8mBIvxuuZ3Buu4xkAGj0yWrrR95FVqQQ==",
-      "dev": true,
-      "requires": {
-        "accept": "3.0.2",
-        "ammo": "3.0.0",
-        "boom": "7.1.1",
-        "bounce": "1.2.0",
-        "call": "5.0.1",
-        "catbox": "10.0.2",
-        "catbox-memory": "3.1.1",
-        "heavy": "6.1.0",
-        "hoek": "5.0.2",
-        "joi": "13.0.2",
-        "mimos": "4.0.0",
-        "podium": "3.1.2",
-        "shot": "4.0.4",
-        "statehood": "6.0.5",
-        "subtext": "6.0.7",
-        "teamwork": "3.0.1",
-        "topo": "3.0.0"
-      }
-    },
     "hapi-capitalize-modules": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/hapi-capitalize-modules/-/hapi-capitalize-modules-1.1.6.tgz",
@@ -1415,17 +1588,6 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
       "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
       "dev": true
-    },
-    "heavy": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/heavy/-/heavy-6.1.0.tgz",
-      "integrity": "sha512-TKS9DC9NOTGulHQI31Lx+bmeWmNOstbJbGMiN3pX6bF+Zc2GKSpbbym4oasNnB6yPGkqJ9TQXXYDGohqNSJRxA==",
-      "dev": true,
-      "requires": {
-        "boom": "7.1.1",
-        "hoek": "5.0.2",
-        "joi": "13.0.2"
-      }
     },
     "hoek": {
       "version": "5.0.2",
@@ -1491,17 +1653,6 @@
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
       "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=",
       "dev": true
-    },
-    "iron": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/iron/-/iron-5.0.4.tgz",
-      "integrity": "sha512-7iQ5/xFMIYaNt9g2oiNiWdhrOTdRUMFaWENUd0KghxwPUhrIH8DUY8FEyLNTTzf75jaII+jMexLdY/2HfV61RQ==",
-      "dev": true,
-      "requires": {
-        "boom": "7.1.1",
-        "cryptiles": "4.1.1",
-        "hoek": "5.0.2"
-      }
     },
     "is-arrayish": {
       "version": "0.2.1",
@@ -2122,9 +2273,9 @@
       "dev": true
     },
     "mime-db": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.32.0.tgz",
-      "integrity": "sha512-+ZWo/xZN40Tt6S+HyakUxnSOgff+JEdaneLWIm0Z6LmpCn5DMcZntLyUY5c/rTDog28LhXLKOUZKoTxTCAdBVw==",
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
+      "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==",
       "dev": true
     },
     "mimic-fn": {
@@ -2132,16 +2283,6 @@
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
       "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg=",
       "dev": true
-    },
-    "mimos": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/mimos/-/mimos-4.0.0.tgz",
-      "integrity": "sha512-JvlvRLqGIlk+AYypWrbrDmhsM+6JVx/xBM5S3AMwTBz1trPCEoPN/swO2L4Wu653fL7oJdgk8DMQyG/Gq3JkZg==",
-      "dev": true,
-      "requires": {
-        "hoek": "5.0.2",
-        "mime-db": "1.32.0"
-      }
     },
     "minimatch": {
       "version": "3.0.4",
@@ -2191,16 +2332,6 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
-    },
-    "nigel": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/nigel/-/nigel-3.0.0.tgz",
-      "integrity": "sha512-ufFVFCe1zS/pfIQzQNa5uJxB8v8IcVTUn1zyPvQwb4CQGRxxBfdQPSXpEnI6ZzIwbV5L+GuAoRhYgcVSvTO7fA==",
-      "dev": true,
-      "requires": {
-        "hoek": "5.0.2",
-        "vise": "3.0.0"
-      }
     },
     "no-arrowception": {
       "version": "1.0.0",
@@ -2326,19 +2457,6 @@
       "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
       "dev": true
     },
-    "pez": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/pez/-/pez-4.0.1.tgz",
-      "integrity": "sha512-0c/SoW5MY7lPdc5U1Q/ixyjLZbluGWJonHVmn4mKwSq7vgO9+a9WzoCopHubIwkot6Q+fevNVElaA+1M9SqHrA==",
-      "dev": true,
-      "requires": {
-        "b64": "4.0.0",
-        "boom": "7.1.1",
-        "content": "4.0.3",
-        "hoek": "5.0.2",
-        "nigel": "3.0.0"
-      }
-    },
     "pify": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
@@ -2415,16 +2533,6 @@
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
       "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
       "dev": true
-    },
-    "podium": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/podium/-/podium-3.1.2.tgz",
-      "integrity": "sha512-18VrjJAduIdPv7d9zWsfmKxTj3cQTYC5Pv5gtKxcWujYBpGbV+mhNSPYhlHW5xeWoazYyKfB9FEsPT12r5rY1A==",
-      "dev": true,
-      "requires": {
-        "hoek": "5.0.2",
-        "joi": "13.0.2"
-      }
     },
     "prelude-ls": {
       "version": "1.1.2",
@@ -2662,16 +2770,6 @@
         }
       }
     },
-    "shot": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/shot/-/shot-4.0.4.tgz",
-      "integrity": "sha512-V8wHSJSNqt8ZIgdbTQCFIrp5BwBH+tsFLNBL1REmkFN/0PJdmzUBQscZqsbdSvdLc+Qxq7J5mcwzai66vs3ozA==",
-      "dev": true,
-      "requires": {
-        "hoek": "5.0.2",
-        "joi": "13.0.2"
-      }
-    },
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
@@ -2738,29 +2836,6 @@
         }
       }
     },
-    "statehood": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/statehood/-/statehood-6.0.5.tgz",
-      "integrity": "sha512-HPa8qT5sGTBVn1Fc9czBYR1oo7gBaay3ysnb04cvcF80YrDIV7880KpjmMj54j7CrFuQFfgMRb44QCRxRmAdTg==",
-      "dev": true,
-      "requires": {
-        "boom": "7.1.1",
-        "bounce": "1.2.0",
-        "cryptiles": "4.1.1",
-        "hoek": "5.0.2",
-        "iron": "5.0.4",
-        "joi": "13.0.2"
-      }
-    },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -2770,6 +2845,15 @@
         "code-point-at": "1.1.0",
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "strip-ansi": {
@@ -2792,19 +2876,6 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true
-    },
-    "subtext": {
-      "version": "6.0.7",
-      "resolved": "https://registry.npmjs.org/subtext/-/subtext-6.0.7.tgz",
-      "integrity": "sha512-IcJUvRjeR+NB437Iq+LORFNJW4L6Knqkj3oQrBrkdhIaS2VKJvx/9aYEq7vi+PEx5/OuehOL/40SkSZotLi/MA==",
-      "dev": true,
-      "requires": {
-        "boom": "7.1.1",
-        "content": "4.0.3",
-        "hoek": "5.0.2",
-        "pez": "4.0.1",
-        "wreck": "14.0.2"
-      }
     },
     "table": {
       "version": "4.0.2",
@@ -2900,12 +2971,6 @@
         }
       }
     },
-    "teamwork": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/teamwork/-/teamwork-3.0.1.tgz",
-      "integrity": "sha512-hEkJIpDOfOYe9NYaLFk00zQbzZeKNCY8T2pRH3I13Y1mJwxaSQ6NEsjY5rCp+11ezCiZpWGoGFTbOuhg4qKevQ==",
-      "dev": true
-    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -3000,15 +3065,6 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
     },
-    "vise": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/vise/-/vise-3.0.0.tgz",
-      "integrity": "sha512-kBFZLmiL1Vm3rHXphkhvvAcsjgeQXRrOFCbJb0I50YZZP4HGRNH+xGzK3matIMcpbsfr3I02u9odj4oCD0TWgA==",
-      "dev": true,
-      "requires": {
-        "hoek": "5.0.2"
-      }
-    },
     "which": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
@@ -3035,16 +3091,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-    },
-    "wreck": {
-      "version": "14.0.2",
-      "resolved": "https://registry.npmjs.org/wreck/-/wreck-14.0.2.tgz",
-      "integrity": "sha512-QCm3omWNJUseqrSzwX2QZi1rBbmCfbFHJAXputLLyZ37VSiFnSYQB0ms/mPnSvrlIu7GVm89Y/gBNhSY26uVIQ==",
-      "dev": true,
-      "requires": {
-        "boom": "7.1.1",
-        "hoek": "5.0.2"
-      }
     },
     "write": {
       "version": "0.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hapi-router",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hapi-router",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "description": "Opinionated route loader for hapi",
   "main": "./lib",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Opinionated route loader for hapi",
   "main": "./lib",
   "scripts": {
-    "test": "standard && lab -r console -o stdout -r lcov -o lcov.info -v -C -a code -m 5000",
+    "test": "standard && lab -r console -o stdout -r lcov -o lcov.info -v -C -a @hapi/code -m 5000",
     "test-dirty": "lab -v -C -a code -m 5000"
   },
   "repository": {
@@ -24,13 +24,13 @@
   },
   "homepage": "https://github.com/bsiddiqui/hapi-router",
   "devDependencies": {
-    "code": "^5.1.2",
-    "hapi": "^17.0.0",
+    "@hapi/code": "^5.3.1",
+    "@hapi/hapi": "^18.3.1",
     "lab": "^15.1.2",
     "standard": "^10.0.3"
   },
   "peerDependencies": {
-    "hapi": "^17.0.0"
+    "@hapi/hapi": "^18.3.1"
   },
   "dependencies": {
     "cast-array": "^1.0.0",

--- a/test/index.js
+++ b/test/index.js
@@ -1,8 +1,8 @@
 'use strict'
 
 var lab = exports.lab = require('lab').script()
-var Hapi = require('hapi')
-var expect = require('code').expect
+var Hapi = require('@hapi/hapi')
+var expect = require('@hapi/code').expect
 
 lab.describe('hapi-router', () => {
   var server


### PR DESCRIPTION
The npm package hapi has been deprecated, and they moved to namespaced version @hapi/hapi with version 18.2.0, see https://github.com/hapijs/hapi/commit/eb89f71df7f8ecc48559eeeffbe3414205b45691.