### PR TITLE
Allow Multiple Plugins

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -24,6 +24,6 @@ exports.register = function (server, options, next) {
 }
 
 exports.register.attributes = {
-  multiple: false,
+  multiple: true,
   pkg: require('../package.json')
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hapi-router",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "description": "Opinionated route loader for hapi",
   "main": "./lib",
   "scripts": {


### PR DESCRIPTION
# Description

This is a proposed `3.5.1` change to hapi-router to allow multiple instances of the plugin. We would like to build a`v2` version of our API using the same route loading system. Unfortunately, the plugin cannot be loaded twice and we get an error.

Changing `multiple: true` in the local `node_modules` version showed no issues / regressions.

```
    {
      register: require('hapi-router'),
      options: { routes: 'resources/**/routes.js' },
      routes: { prefix: '/v1' }
    },
    {
      register: require('hapi-router'),
      options: { routes: 'resources/**/routes-v2.js' },
      routes: { prefix: '/v2' }
    }
```

/cc @bsiddiqui